### PR TITLE
Handle aviationweather 400 errors by retrying without mostRecent flags

### DIFF
--- a/CFPS_WEATHER_NOTAM.py
+++ b/CFPS_WEATHER_NOTAM.py
@@ -264,8 +264,22 @@ def get_metar_reports(icao_codes: tuple[str, ...]):
         "hours": 3,
     }
 
-    response = requests.get(url, params=params, timeout=10)
-    response.raise_for_status()
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        status_code = getattr(exc.response, "status_code", None)
+        if status_code == 400:
+            fallback_params = {
+                "ids": params["ids"],
+                "format": "JSON",
+                "hours": 3,
+            }
+            response = requests.get(url, params=fallback_params, timeout=10)
+            response.raise_for_status()
+        else:
+            raise
+
     data = response.json()
 
     reports = {}
@@ -302,8 +316,21 @@ def get_taf_reports(icao_codes: tuple[str, ...]):
         "mostRecent": "true",
     }
 
-    response = requests.get(url, params=params, timeout=10)
-    response.raise_for_status()
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        status_code = getattr(exc.response, "status_code", None)
+        if status_code == 400:
+            fallback_params = {
+                "ids": params["ids"],
+                "format": "JSON",
+            }
+            response = requests.get(url, params=fallback_params, timeout=10)
+            response.raise_for_status()
+        else:
+            raise
+
     data = response.json()
 
     taf_reports = {}


### PR DESCRIPTION
## Summary
- add defensive retry logic for METAR requests that receive a 400 error by removing the mostRecent parameters
- add the same retry logic for TAF requests so the UI still displays forecasts when the new API rejects the original query

## Testing
- python -m py_compile CFPS_WEATHER_NOTAM.py

------
https://chatgpt.com/codex/tasks/task_e_68d5aa52d038833394eef3ebe7ad3277