### PR TITLE
Fix aviationweather API format parameter

### DIFF
--- a/CFPS_WEATHER_NOTAM.py
+++ b/CFPS_WEATHER_NOTAM.py
@@ -258,7 +258,7 @@ def get_metar_reports(icao_codes: tuple[str, ...]):
     url = "https://aviationweather.gov/api/data/metar"
     params = {
         "ids": ",".join(sorted(set(code.upper() for code in icao_codes))),
-        "format": "JSON",
+        "format": "json",
         "mostRecent": "true",
         "mostRecentForEachStation": "true",
         "hours": 3,
@@ -272,7 +272,7 @@ def get_metar_reports(icao_codes: tuple[str, ...]):
         if status_code == 400:
             fallback_params = {
                 "ids": params["ids"],
-                "format": "JSON",
+                "format": "json",
                 "hours": 3,
             }
             response = requests.get(url, params=fallback_params, timeout=10)
@@ -312,7 +312,7 @@ def get_taf_reports(icao_codes: tuple[str, ...]):
     url = "https://aviationweather.gov/api/data/taf"
     params = {
         "ids": ",".join(sorted(set(code.upper() for code in icao_codes))),
-        "format": "JSON",
+        "format": "json",
         "mostRecent": "true",
     }
 
@@ -324,7 +324,7 @@ def get_taf_reports(icao_codes: tuple[str, ...]):
         if status_code == 400:
             fallback_params = {
                 "ids": params["ids"],
-                "format": "JSON",
+                "format": "json",
             }
             response = requests.get(url, params=fallback_params, timeout=10)
             response.raise_for_status()


### PR DESCRIPTION
## Summary
- use lowercase json format parameter when requesting METAR and TAF data from aviationweather.gov
- adjust fallback requests to match the API's expected format value

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5ad50ec948333a0abc0e3dcff9859