### PR TITLE
Handle nested TAF visibility values

### DIFF
--- a/CFPS_WEATHER_NOTAM.py
+++ b/CFPS_WEATHER_NOTAM.py
@@ -301,6 +301,26 @@ def _parse_visibility_value(value) -> float | None:
     if isinstance(value, (int, float)):
         return float(value)
 
+    if isinstance(value, dict):
+        for key in ("value", "visibility", "minValue", "maxValue"):
+            if key in value:
+                nested_val = _parse_visibility_value(value[key])
+                if nested_val is not None:
+                    return nested_val
+        for key in ("repr", "text", "raw", "string"):
+            if key in value:
+                nested_val = _parse_visibility_value(value[key])
+                if nested_val is not None:
+                    return nested_val
+        return None
+
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            nested_val = _parse_visibility_value(item)
+            if nested_val is not None:
+                return nested_val
+        return None
+
     text = str(value).strip().upper()
     if not text:
         return None


### PR DESCRIPTION
## Summary
- update visibility parsing to understand nested dictionary and list structures returned by NOAA APIs
- ensure low-visibility forecasts in TAF data trigger the existing highlight styling

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5bbbd4d308333919275783cd44814